### PR TITLE
update filepath for save summary results for compatibility with aquanet-mod new structure

### DIFF
--- a/R/simulationCode.R
+++ b/R/simulationCode.R
@@ -438,8 +438,9 @@ simulationCode <- function(runs,
   #                         filepath_results = filepath_results)
 
   # save table containing number of sites in each state at each time point
+  # TODO update this so the filepath isn't hard-coded once aquanet-mod pr is merged
   save(summaryStates.table,
-       file = paste(filepath_results, "/Summary/batchNo-", batch_num, ".RData", sep = ""),
+       file = paste(filepath_results, "/batch_results/batchNo-", batch_num, ".RData", sep = ""),
        compress = FALSE)
 
   return(batch_num)


### PR DESCRIPTION
Address issue with runSimulation and simulationCode not running with aquanet-mod scripts due to differing file structures for saving output.

The folder Summary/ is now named batch_results/ - file names remain unchanged.

Note: need to input multiple result directories or the dirs object created in aquanet-mod pull request by Becca to ensure that the folder structure is not hard-coded.