### PR TITLE
update file paths for saving results

### DIFF
--- a/R/commitResults.R
+++ b/R/commitResults.R
@@ -31,7 +31,8 @@
 #'
 #' @param save_num (class numeric) number of full saves for model run.
 #'
-#' @param filepath_results (class string) path to results directory for model run.
+#' @param filepath_results (class character) character vector containing paths to various results
+#' directories for model run created in `aquanet-mod/code/RunModelCommandLine.R`.
 #'
 #' @return Saved .RData file containing data frame located within the `filepath_results`
 #' full_results directory. Output data frame `sims` contains model ID, site ID, infection and
@@ -72,8 +73,8 @@ commitResults <- function(df_states,
 
   # save simulation site states and simulation times
   save(sims,
-       file = paste(filepath_results,
-                    "/full_results/batchNo-", batch_num,
+       file = paste(filepath_results[["results_full"]],
+                    "/batchNo-", batch_num,
                     "_simNo-", simulation_num,
                     "_NoCommits-", save_num,
                     ".RData",

--- a/R/runSimulations.R
+++ b/R/runSimulations.R
@@ -72,7 +72,8 @@
 #' infected catchments, and 2 = allows no movements by any of the sites within an infected
 #' catchment, "None" means there are no catchment level controls).
 #'
-#' @param filepath_results (class string) path to results directory for model run.
+#' @param filepath_results (class character) character vector containing paths to various results
+#' directories for model run created in `aquanet-mod/code/RunModelCommandLine.R`.
 #'
 #' @param contact_tracing (class logical) vector of length 1 indicating whether or not contact
 #' tracing should take place.
@@ -125,7 +126,7 @@ runSimulations <- function(n_cores,
 
   if (clear_results == TRUE) {
   # list files ending in .RData in the results directory
-  files <- list.files(path = filepath_results,
+  files <- list.files(path = filepath_results[["results"]],
                       pattern = "\\.RData$",
                       recursive = TRUE,
                       full.names = TRUE)

--- a/R/simulationCode.R
+++ b/R/simulationCode.R
@@ -92,7 +92,8 @@
 #' infected catchments, and 2 = allows no movements by any of the sites within an infected
 #' catchment, "None" means there are no catchment level controls).
 #'
-#' @param filepath_results (class string) path to results directory for model run.
+#' @param filepath_results (class character) character vector containing paths to various results
+#' directories for model run created in `aquanet-mod/code/RunModelCommandLine.R`.
 #'
 #' @param contact_tracing (class logical) vector of length 1 indicating whether or not contact
 #' tracing should take place.
@@ -463,7 +464,7 @@ simulationCode <- function(runs,
 
   # save table containing number of sites in each state at each time point
   save(output_summary_states,
-       file = paste(filepath_results, "/batch_results/batchNo-", batch_num, ".RData", sep = ""),
+       file = paste(filepath_results[["results_batch"]], "/batchNo-", batch_num, ".RData", sep = ""),
        compress = FALSE)
 
   return(batch_num)

--- a/man/commitResults.Rd
+++ b/man/commitResults.Rd
@@ -45,7 +45,8 @@ model (note, include some redundancy here).}
 
 \item{save_num}{(class numeric) number of full saves for model run.}
 
-\item{filepath_results}{(class string) path to results directory for model run.}
+\item{filepath_results}{(class character) character vector containing paths to various results
+directories for model run created in \code{aquanet-mod/code/RunModelCommandLine.R}.}
 }
 \value{
 Saved .RData file containing data frame located within the \code{filepath_results}

--- a/man/runSimulations.Rd
+++ b/man/runSimulations.Rd
@@ -90,7 +90,8 @@ apply (0 = allows movements within the same catchments, 1 = allows movements wit
 infected catchments, and 2 = allows no movements by any of the sites within an infected
 catchment, "None" means there are no catchment level controls).}
 
-\item{filepath_results}{(class string) path to results directory for model run.}
+\item{filepath_results}{(class character) character vector containing paths to various results
+directories for model run created in \code{aquanet-mod/code/RunModelCommandLine.R}.}
 
 \item{contact_tracing}{(class logical) vector of length 1 indicating whether or not contact
 tracing should take place.}

--- a/man/simulationCode.Rd
+++ b/man/simulationCode.Rd
@@ -82,7 +82,8 @@ apply (0 = allows movements within the same catchments, 1 = allows movements wit
 infected catchments, and 2 = allows no movements by any of the sites within an infected
 catchment, "None" means there are no catchment level controls).}
 
-\item{filepath_results}{(class string) path to results directory for model run.}
+\item{filepath_results}{(class character) character vector containing paths to various results
+directories for model run created in \code{aquanet-mod/code/RunModelCommandLine.R}.}
 
 \item{contact_tracing}{(class logical) vector of length 1 indicating whether or not contact
 tracing should take place.}


### PR DESCRIPTION
Change filepath_results input for runSimulations, simulationCode and commitResults to be `dirs` instead of `dirs[["results"]]` so file paths for outputs are not hard-coded