### PR TITLE
add days_before_catchment_restocking parameter

### DIFF
--- a/R/doEvent.R
+++ b/R/doEvent.R
@@ -6,7 +6,8 @@
 #' (see details).
 #'
 #' First, create variable a logical vector to store information on whether all sites in a catchment
-#' have been in a post-fallow state for at least 4 days and are therefore ready to restock.
+#' have been in a post-fallow state for at least `days_before_catchment_restock` days and are
+#' therefore ready to restock.
 #'
 #' Next, extract required information from function inputs: sites that are fallow,  sites subject to
 #'  transition identified in `transition rates[[2]]`, total number of possible site transitions, a
@@ -40,8 +41,9 @@
 #' If sites have been in a fallow state for required number of days convert controls to post-fallow
 #' state. Check catchment level restocking to identify catchments containing only post-fallow sites
 #'  and reset the `catchment_time_vector` to 0 for these. If these catchments have been in a ready
-#' to restock state for greater than or equal to 4 days then move the sites within these catchments
-#' to a no disease control state and reset the `time_vector` for these sites.
+#' to restock state for greater than or equal to `days_before_catchment_restock` days then move the
+#' sites within these catchments to a no disease control state and reset the `time_vector` for
+#' these sites.
 #'
 #' @param state_vector (class numeric) numeric binary vector of length 'number of sites' containing
 #' information about the state of each site in relation to a condition. This state vector should
@@ -99,6 +101,9 @@
 #' @param contact_tracing (class logical) vector of length 1 indicating whether or not contact
 #' tracing is taking place.
 #'
+#' @param days_before_catchment_restock (class numeric) number of days that all sites within a
+#' catchment need to be in the post-fallow state before restocking.
+#'
 #'
 #' @return (class list) of length 8 containing:
 #' 1. (class numeric) `state_vector` numeric binary vector of length 'number of sites' containing
@@ -141,7 +146,8 @@ doEvent <- function(state_vector,
                     catchments_with_post_fallow_only,
                     source_inf_vector,
                     source_inf_matrix,
-                    contact_tracing) {
+                    contact_tracing,
+                    days_before_catchment_restock) {
 
   ## create variables to populate ----
 
@@ -430,8 +436,8 @@ doEvent <- function(state_vector,
     catchments_with_post_fallow_only <- catchment_restocking[[3]]
   }
 
-  # select catchments for restock - with only post-fallow sites ready to restock for >= 4 days
-  catchments_ready_restock[catchments_with_post_fallow_only] <- catchment_time_vector[catchments_with_post_fallow_only] >= 4
+  # select catchments for restock - with only post-fallow sites ready to restock for >= X days
+  catchments_ready_restock[catchments_with_post_fallow_only] <- catchment_time_vector[catchments_with_post_fallow_only] >= days_before_catchment_restock
 
   # total number of catchments ready for restock
   n_catchments_ready_restock <- sum(as.numeric(catchments_ready_restock))

--- a/R/runSimulations.R
+++ b/R/runSimulations.R
@@ -90,6 +90,9 @@
 #'
 #' @param proportion_cullable (class numeric) proportion of fisheries able to cull site.
 #'
+#' @param days_before_catchment_restock (class numeric) number of days that all sites within a
+#' catchment need to be in the post-fallow state before restocking.
+#'
 #' @return (class list) of length 2 containing:
 #' 1. (class numeric) the number of cores used for the run.
 #' 2. the output of the foreach loop running the `aquanet::simulationCode()` function.
@@ -122,7 +125,8 @@ runSimulations <- function(n_cores,
                            remove_top_sites,
                            n_infections_remove_top_sites,
                            disease_controls,
-                           proportion_cullable) {
+                           proportion_cullable,
+                           days_before_catchment_restock) {
 
   if (clear_results == TRUE) {
   # list files ending in .RData in the results directory
@@ -176,7 +180,8 @@ runSimulations <- function(n_cores,
       remove_top_sites = remove_top_sites,
       n_infections_remove_top_sites = n_infections_remove_top_sites,
       disease_controls = disease_controls,
-      proportion_cullable = proportion_cullable
+      proportion_cullable = proportion_cullable,
+      days_before_catchment_restock = days_before_catchment_restock
     )
 
   # shut down set of copies of R running in parallel communicating over sockets

--- a/R/simulationCode.R
+++ b/R/simulationCode.R
@@ -113,6 +113,9 @@
 #' @return (class numeric) batch number `batch_num` and output_summary_states saved to
 #' `filepath_results`.
 #'
+#' @param days_before_catchment_restock (class numeric) number of days that all sites within a
+#' catchment need to be in the post-fallow state before restocking.
+#'
 #'
 #' @export
 #'
@@ -140,7 +143,8 @@ simulationCode <- function(runs,
                            remove_top_sites,
                            n_infections_remove_top_sites,
                            disease_controls,
-                           proportion_cullable) {
+                           proportion_cullable,
+                           days_before_catchment_restock) {
 
   ## extract information from input parameters ----
 
@@ -418,7 +422,8 @@ simulationCode <- function(runs,
                                       catchments_with_post_fallow_only = catchments_with_post_fallow_only,
                                       source_inf_vector = source_inf_vector,
                                       source_inf_matrix = source_inf_matrix,
-                                      contact_tracing = contact_tracing)
+                                      contact_tracing = contact_tracing,
+                                      days_before_catchment_restock = days_before_catchment_restock)
 
       # reassign variables with updates outputs for next iteration of while loop
       state_vector <- doEvent_out[[1]]

--- a/man/doEvent.Rd
+++ b/man/doEvent.Rd
@@ -19,7 +19,8 @@ doEvent(
   catchments_with_post_fallow_only,
   source_inf_vector,
   source_inf_matrix,
-  contact_tracing
+  contact_tracing,
+  days_before_catchment_restock
 )
 }
 \arguments{
@@ -80,6 +81,9 @@ connectivity'. Note: this matrix is used for forward contact tracing.}
 
 \item{contact_tracing}{(class logical) vector of length 1 indicating whether or not contact
 tracing is taking place.}
+
+\item{days_before_catchment_restock}{(class numeric) number of days that all sites within a
+catchment need to be in the post-fallow state before restocking.}
 }
 \value{
 (class list) of length 8 containing:
@@ -117,7 +121,8 @@ of the transition event and the amount of time each site or group of sites are i
 }
 \details{
 First, create variable a logical vector to store information on whether all sites in a catchment
-have been in a post-fallow state for at least 4 days and are therefore ready to restock.
+have been in a post-fallow state for at least \code{days_before_catchment_restock} days and are
+therefore ready to restock.
 
 Next, extract required information from function inputs: sites that are fallow,  sites subject to
 transition identified in \verb{transition rates[[2]]}, total number of possible site transitions, a
@@ -151,6 +156,7 @@ control state.
 If sites have been in a fallow state for required number of days convert controls to post-fallow
 state. Check catchment level restocking to identify catchments containing only post-fallow sites
 and reset the \code{catchment_time_vector} to 0 for these. If these catchments have been in a ready
-to restock state for greater than or equal to 4 days then move the sites within these catchments
-to a no disease control state and reset the \code{time_vector} for these sites.
+to restock state for greater than or equal to \code{days_before_catchment_restock} days then move the
+sites within these catchments to a no disease control state and reset the \code{time_vector} for
+these sites.
 }

--- a/man/runSimulations.Rd
+++ b/man/runSimulations.Rd
@@ -27,7 +27,8 @@ runSimulations(
   remove_top_sites,
   n_infections_remove_top_sites,
   disease_controls,
-  proportion_cullable
+  proportion_cullable,
+  days_before_catchment_restock
 )
 }
 \arguments{
@@ -107,6 +108,9 @@ probability matrix.}
 any disease control measures should take place.}
 
 \item{proportion_cullable}{(class numeric) proportion of fisheries able to cull site.}
+
+\item{days_before_catchment_restock}{(class numeric) number of days that all sites within a
+catchment need to be in the post-fallow state before restocking.}
 }
 \value{
 (class list) of length 2 containing:

--- a/man/simulationCode.Rd
+++ b/man/simulationCode.Rd
@@ -25,7 +25,8 @@ simulationCode(
   remove_top_sites,
   n_infections_remove_top_sites,
   disease_controls,
-  proportion_cullable
+  proportion_cullable,
+  days_before_catchment_restock
 )
 }
 \arguments{
@@ -99,6 +100,9 @@ probability matrix.}
 any disease control measures should take place.}
 
 \item{proportion_cullable}{(class numeric) proportion of fisheries able to cull site.}
+
+\item{days_before_catchment_restock}{(class numeric) number of days that all sites within a
+catchment need to be in the post-fallow state before restocking.}
 }
 \value{
 (class numeric) batch number \code{batch_num} and output_summary_states saved to


### PR DESCRIPTION
update aquanet functions doEvent, simulationCode and runSimulations to incorporate a days_before_catchment_restock parameter that can be adjusted